### PR TITLE
Ignoring clion generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 src/zoic.dylib
 tests/*
 build/*
+.idea
+cmake-build-debug
+cmake-build-release


### PR DESCRIPTION
This simple change ignores the files generated by clion. Project files inside .idea, and cmake-build-debug and cmake-build-release for the build files / cmake configs inside the project.