### PR TITLE
Restore SCons build, remove global variables, remove use of deprecated AtParamValue array, c++0x compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 src/zoic.dylib
 tests/*
 build/*
+
+/.build
+/release
+/debug
+*.dblite
+excons.cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "excons"]
+	path = excons
+	url = git://github.com:gatgui/excons.git

--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,55 @@
+import os
+import sys
+import glob
+import excons
+from excons.tools import arnold
+
+
+version = "2.0.0"
+
+excons.SetArgument("use-c++11", 1)
+
+env = excons.MakeBaseEnv()
+
+if sys.platform != "win32":
+    env.Append(CPPFLAGS=" -Wno-unused-parameter -Wno-unused-variable")
+
+defs = []
+incdirs = []
+libdirs = []
+libs = []
+
+# Zeno specific flags
+if excons.GetArgument("draw", 0, int) != 0:
+    defs.append("_DRAW")
+if excons.GetArgument("work", 0, int) != 0:
+    defs.append("_WORK")
+if excons.GetArgument("macbook", 0, int) != 0:
+    defs.append("_MACBOOK")
+
+# Arnold 4.2.9.0 provides api AiTextureLoad to read texture data
+# Arnold 4.2.10.0 adds a new parameter to the function above
+arniver = arnold.Version(asString=False)
+if arniver[0] < 4 or (arniver[0] == 4 and (arniver[1] < 2 or (arniver[1] == 2 and arniver[2] < 10))):
+    print("Arnold 4.2.10.0 at least required")
+    sys.exit(1)
+
+zoic = {"name": "zoic",
+        "type": "dynamicmodule",
+        "prefix": "arnold",
+        "ext": arnold.PluginExt(),
+        "srcs": ["src/zoic.cpp"],
+        "defs": defs,
+        "incdirs": incdirs,
+        "libdirs": libdirs,
+        "libs": libs,
+        "custom": [arnold.Require]}
+
+targets = excons.DeclareTargets(env, [zoic])
+
+out_prefix = excons.OutputBaseDirectory() + "/"
+
+env.Depends(targets["zoic"], env.Install(out_prefix + "arnold", "src/zoic.mtd"))
+env.Depends(targets["zoic"], env.Install(out_prefix + "maya", glob.glob("maya/*")))
+env.Depends(targets["zoic"], env.Install(out_prefix + "c4d", glob.glob("c4d/*")))
+env.Depends(targets["zoic"], env.Install(out_prefix + "data/lenses", glob.glob("lenses_tabular/*.dat")))


### PR DESCRIPTION
Sorry for the lengthy title, but the changes kind were depending on one another so I couldn't split in finer PRs. The main points are:

- Restoring SCons build script that has disappeared between version 1.1 and 2.0
- Removing dependency to C++11: the code is not really using any of the c++11 killer feature so asking for a C++11 compatible compiler is not really a must
- Removing usage of deprecated AtParamValue array
- Removing usage of global variables but for 2 constant strings holding you local drive paths. By the way, I'd suggest you use another mean (environment variables for example) instead of hardcoding paths in the source code as it is a rather bad practice
